### PR TITLE
Updated debuf item finding value

### DIFF
--- a/villager-bot/cogs/commands/econ.py
+++ b/villager-bot/cogs/commands/econ.py
@@ -1031,7 +1031,7 @@ class Econ(commands.Cog):
         # see if user has chugged a luck potion
         lucky = (await self.ipc.eval(f"'luck potion' in active_effects[{ctx.author.id}]")).result
 
-        item_chance_debuff = 2  # the higher the value, the lesser the chance, 1 is normal rarity.
+        item_chance_debuff = 1.3  # the higher the value, the lesser the chance, 1 is normal rarity.
 
         for item in self.d.mining.findables:  # try to see if user gets an item
             # int() isn't rly necessary but might prevent bugs from tweaking later


### PR DESCRIPTION
I think I nerfed it too much when doing that
Before chances of looking for an item were "divided" by something between 1.15 (wood pick) and 1.5 (netherite pick) so 2 is way too much compared to before
I picked a value in between those : 1.3 and it should make mining items somewhat like before that rework