### PR TITLE
CI / formatting improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,23 +31,13 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: install dependencies
-#        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install
 
-      - name: auto-flake
-        run: poetry run autoflake --remove-all-unused-imports --expand-star-imports --ignore-init-module-imports --in-place --recursive bot/ common/ karen/
+      - name: black check
+        run: poetry run black . --check
 
-      - name: black fix
-        run: poetry run black .
-
-      - name: isort fix
-        run: poetry run isort .
-
-      - name: auto commit
-        if: github.ref != 'refs/heads/main'
-        uses: stefanzweifel/git-auto-commit-action@v4.15.4
-        with:
-          commit_message: format / fix code
+      - name: isort check
+        run: poetry run isort . --check
 
       - name: flake8
         run: poetry run flake8
@@ -58,5 +48,5 @@ jobs:
       - name: pytest
         run: poetry run pytest
 
-      - name: json-check
+      - name: json check
         run: "find bot karen common -name \"*.json\" | while read file; do { echo \"Checking file: $file\"; jq . $file -c > /dev/null; }; done"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@
 ## Contributing
 - Before contributing please discuss your proposed changes in the [Discord server](https://discord.gg/39DwwUV)
 - Please open a [PR (pull request)](https://github.com/Iapetus-11/Villager-Bot/pulls) to have your changes reviewed and merged
+- You should run the `format` script (`poetry run format`) provided to format your code prior to submitting your PR or the PR checks will fail
 
 ## Technical discussion/questions/help
 - Please join the [Discord server](https://discord.gg/39DwwUV) and use the `#💻tech-talk` channel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ version = "0.0.1"
 description = ""
 authors = ["Milo Weinberg <iapetus011@gmail.com>"]
 license = "MIT"
+packages = [
+    { include = "bot" },
+    { include = "common" },
+    { include = "karen" },
+    { include = "scripts" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.10"
@@ -41,6 +47,9 @@ autoflake = "^1.4"
 pytest = "^7.1.3"
 types-aiofiles = "^22.1.0.9"
 
+[tool.poetry.scripts]
+format = { callable = "scripts.format:run" }
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
@@ -60,7 +69,7 @@ sections = ["FUTURE", "STDLIB", "THIRDPARTY", "COMMON", "BOT", "KAREN", "FIRSTPA
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]
-files = ["common/**/*.py", "karen/**/*.py"]
+files = ["common/**/*.py", "karen/**/*.py", "scripts/**/*.py"]
 python_version = "3.10"
 warn_unused_configs = true
 namespace_packages = true

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,0 +1,16 @@
+import os
+
+SYSTEM_CMDS = [
+    "poetry run autoflake --remove-all-unused-imports --expand-star-imports --ignore-init-module-imports --in-place --recursive bot/ common/ karen/ scripts/",
+    "poetry run isort .",
+    "poetry run black .",
+]
+
+
+def run():
+    for cmd in SYSTEM_CMDS:
+        os.system(cmd)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
1. Remove autoformatting from the CI GitHub Action and only check code style
    - Adding another commit to format code seems spammy and I don't like it anymore
    - It didn't work on PRs coming from forks
2. Add a `format` script (`poetry run format`)
    - Now that the code is not automatically formatted but still checked, there should be an easy way for contributors/developers to format their code