### PR TITLE
fix tw lb emoji + enderman finisher translations

### DIFF
--- a/bot/cogs/commands/econ.py
+++ b/bot/cogs/commands/econ.py
@@ -2183,7 +2183,7 @@ class Econ(commands.Cog):
                 ctx,
                 global_lb=global_lb,
                 local_lb=local_lb,
-                row_fmt=f"\n`{{}}.` **{{}}** {self.d.emojis.emerald_block} {{}}",
+                row_fmt=f"\n`{{}}.` **{{}}** {self.d.emojis.emerald} {{}}",
                 title=ctx.l.econ.lb.lb_tw.format(f" {self.d.emojis.emerald_block} "),
             )
 

--- a/bot/data/text/en.json
+++ b/bot/data/text/en.json
@@ -1453,7 +1453,7 @@
           "finishers": [
             "The **enderman** teleports you off a cliff",
             "The **enderman** teleports you into the void",
-            "The **enderman** teleports behind you and"
+            "The **enderman** teleports behind you and decapitates you"
           ],
           "misses": [
             "You swing your **{0}** as hard as you can but the **enderman** teleports out of the way.",

--- a/bot/data/text/es.json
+++ b/bot/data/text/es.json
@@ -1453,7 +1453,7 @@
           "finishers": [
             "El **enderman** te teletransporta y te tira de una colina.",
             "El **enderman** te teletransporta en el vacío.",
-            "El **enderman** se teletransporta detrás tuyo y"
+            "El **enderman** se teletransporta detrás de tí y te decapita"
           ],
           "misses": [
             "Blandes tu **{0}** tan fuerte como puedes pero el **enderman** se teletransporta esquivándote.",

--- a/bot/data/text/fr.json
+++ b/bot/data/text/fr.json
@@ -1453,7 +1453,7 @@
           "finishers": [
             "L' **enderman** te fait tomber d'une falaise",
             "L' **enderman** te téléporte dans le vide",
-            "L' **enderman** se téléporte derrière toi et"
+            "L' **enderman** se téléporte derrière vous et vous décapite"
           ],
           "misses": [
             "Tu attaques avec ton **{0}** aussi fort que tu peux mais l' **enderman** se téléporte pour esquiver.",

--- a/bot/data/text/pt.json
+++ b/bot/data/text/pt.json
@@ -1453,7 +1453,7 @@
           "finishers": [
             "O **enderman** teletransporta você de um penhasco",
             "O **enderman** teletransporta você para o void",
-            "O **enderman** se teletransporta atrás de você e"
+            "O **enderman** se teletransporta atrás de você e te decapita"
           ],
           "misses": [
             "Você balança sua **{0}** o mais forte que pode, mas o **enderman** se teletransporta para fora do caminho.",


### PR DESCRIPTION
- Change the row emojis in the Total Wealth Leaderboard from `emerald_block` -> `emerald`
- Fix incomplete translations for the enderman finisher line