### PR TITLE
fix deprecated behaviour for asyncio.wait()

### DIFF
--- a/karen/karen.py
+++ b/karen/karen.py
@@ -275,10 +275,10 @@ ON js.guild_id = ls.guild_id WHERE (COALESCE(js.c, 0) - COALESCE(ls.c, 0)) > 0""
             "RETURNING channel_id, user_id, message_id, reminder",
         )
 
-        broadcast_coros = [self.server.broadcast(PacketType.REMINDER, {**r}) for r in reminders]
+        broadcast_tasks = [asyncio.create_task(self.server.broadcast(PacketType.REMINDER, {**r})) for r in reminders]
 
-        for coros_chunk in chunk_sequence(broadcast_coros, 4):
-            await asyncio.wait(coros_chunk)
+        for tasks_chunk in chunk_sequence(broadcast_tasks, 4):
+            await asyncio.wait(tasks_chunk)
 
     @recurring_task(minutes=30, sleep_first=False)
     async def loop_clear_weekly_leaderboards(self):

--- a/karen/karen.py
+++ b/karen/karen.py
@@ -275,7 +275,10 @@ ON js.guild_id = ls.guild_id WHERE (COALESCE(js.c, 0) - COALESCE(ls.c, 0)) > 0""
             "RETURNING channel_id, user_id, message_id, reminder",
         )
 
-        broadcast_tasks = [asyncio.create_task(self.server.broadcast(PacketType.REMINDER, {**r})) for r in reminders]
+        broadcast_tasks = [
+            asyncio.create_task(self.server.broadcast(PacketType.REMINDER, {**r}))
+            for r in reminders
+        ]
 
         for tasks_chunk in chunk_sequence(broadcast_tasks, 4):
             await asyncio.wait(tasks_chunk)


### PR DESCRIPTION
This PR implements a fix for what was unintentionally left out of #319

- Implement similar `asyncio.Task` behaviour in the reminders loop, which was previously non-functional in ver`3.11+` due to the same error (`TypeError: Passing coroutines is forbidden, use tasks explicitly`)
- Tested locally and works fine

With this, all references to `asyncio.wait()` in the code now consistently use Tasks (and other accepted asynchronus constructs) instead of raw coroutines