### PR TITLE
Make years dynamic in mob attacks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2024 Iapetus-11
+Copyright (c) 2021-2025 Iapetus-11
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bot/cogs/core/mobs.py
+++ b/bot/cogs/core/mobs.py
@@ -290,8 +290,10 @@ class MobSpawner(commands.Cog):
                     break
                 # send mob attack
                 mob_attack_text = random.choice(mob.attacks)
-                if "{}" in mob_attack_text:
-                    mob_attack_text = mob_attack_text.format(datetime.now(tz=timezone.utc).year)
+                if "{current_year}" in mob_attack_text:
+                    mob_attack_text = mob_attack_text.format(
+                        current_year=datetime.now(tz=timezone.utc).year
+                    )
 
                 await ctx.send_embed(mob_attack_text)
 

--- a/bot/cogs/core/mobs.py
+++ b/bot/cogs/core/mobs.py
@@ -6,6 +6,7 @@ import typing
 
 import classyjson as cj
 import discord
+from datetime import datetime, timezone
 from discord.ext import commands
 
 from bot.cogs.core.database import Database
@@ -288,7 +289,11 @@ class MobSpawner(commands.Cog):
                     await ctx.send_embed(random.choice(mob.finishers))
                     break
                 # send mob attack
-                await ctx.send_embed(random.choice(mob.attacks))
+                mob_attack_text = random.choice(mob.attacks)
+                if "{}" in mob_attack_text:
+                    mob_attack_text = mob_attack_text.format(datetime.now(tz=timezone.utc).year)
+
+                await ctx.send_embed(mob_attack_text)
 
                 async with SuppressCtxManager(ctx.typing()):
                     await asyncio.sleep(0.75 + random.random() * 2)

--- a/bot/data/text/en.json
+++ b/bot/data/text/en.json
@@ -1368,7 +1368,7 @@
             "The **skeleton** turns around and 360 no scopes you!",
             "An arrow rains from the **skeleton**, only one.",
             "One headshot from the **skeleton** for you!",
-            "BOOM! HEADSHOT! - **skeleton** {}"
+            "BOOM! HEADSHOT! - **skeleton** {current_year}"
           ],
           "finishers": [
             "The **skeleton** 360 noscopes you for the last time!",

--- a/bot/data/text/en.json
+++ b/bot/data/text/en.json
@@ -1368,7 +1368,7 @@
             "The **skeleton** turns around and 360 no scopes you!",
             "An arrow rains from the **skeleton**, only one.",
             "One headshot from the **skeleton** for you!",
-            "BOOM! HEADSHOT! - **skeleton** 2025"
+            "BOOM! HEADSHOT! - **skeleton** {}"
           ],
           "finishers": [
             "The **skeleton** 360 noscopes you for the last time!",

--- a/bot/data/text/es.json
+++ b/bot/data/text/es.json
@@ -1368,7 +1368,7 @@
             "¡El **esqueleto** dió un giro de 360° y sin apuntar te dió!",
             "El **esqueleto** te lanza una flecha, sólo una.",
             "¡Un tiro en la cabeza del **esqueleto** da en ti!",
-            "¡BOOM! ¡UN TIRO EN LA CABEZA! - **esqueleto** {}"
+            "¡BOOM! ¡UN TIRO EN LA CABEZA! - **esqueleto** {current_year}"
           ],
           "finishers": [
             "El **esqueleto** dió un giro de 360° y sin apuntar te dió por ultima vez!",

--- a/bot/data/text/es.json
+++ b/bot/data/text/es.json
@@ -1368,7 +1368,7 @@
             "¡El **esqueleto** dió un giro de 360° y sin apuntar te dió!",
             "El **esqueleto** te lanza una flecha, sólo una.",
             "¡Un tiro en la cabeza del **esqueleto** da en ti!",
-            "¡BOOM! ¡UN TIRO EN LA CABEZA! - **esqueleto** 2025"
+            "¡BOOM! ¡UN TIRO EN LA CABEZA! - **esqueleto** {}"
           ],
           "finishers": [
             "El **esqueleto** dió un giro de 360° y sin apuntar te dió por ultima vez!",

--- a/bot/data/text/fr.json
+++ b/bot/data/text/fr.json
@@ -1368,7 +1368,7 @@
             "Le **squelette** te fait un 360 no scope !",
             "Il pleut une flêche du **squelette**, seulement une",
             "Un headshot du **squelette** pour toi",
-            "BOOM! HEADSHOT! - **squelette** {}"
+            "BOOM! HEADSHOT! - **squelette** {current_year}"
           ],
           "finishers": [
             "Le **squelette** te fait un 360 noscope pour la dernière fois !",

--- a/bot/data/text/fr.json
+++ b/bot/data/text/fr.json
@@ -1368,7 +1368,7 @@
             "Le **squelette** te fait un 360 no scope !",
             "Il pleut une flêche du **squelette**, seulement une",
             "Un headshot du **squelette** pour toi",
-            "BOOM! HEADSHOT! - **squelette** 2025"
+            "BOOM! HEADSHOT! - **squelette** {}"
           ],
           "finishers": [
             "Le **squelette** te fait un 360 noscope pour la dernière fois !",

--- a/bot/data/text/pt.json
+++ b/bot/data/text/pt.json
@@ -1368,7 +1368,7 @@
             "O **esqueleto** deu um 360 e sem mira atingiu você!",
             "Uma flecha foi lançada do **esqueleto**, apenas uma.",
             "Um tiro na cabeça do **esqueleto** para você!",
-            "BOOM! TIRO NA CABEÇA! - **esqueleto** {}"
+            "BOOM! TIRO NA CABEÇA! - **esqueleto** {current_year}"
           ],
           "finishers": [
             "O **esqueleto** te deu um 360 sem mira em você pela última vez!",

--- a/bot/data/text/pt.json
+++ b/bot/data/text/pt.json
@@ -1368,7 +1368,7 @@
             "O **esqueleto** deu um 360 e sem mira atingiu você!",
             "Uma flecha foi lançada do **esqueleto**, apenas uma.",
             "Um tiro na cabeça do **esqueleto** para você!",
-            "BOOM! TIRO NA CABEÇA! - **esqueleto** 2025"
+            "BOOM! TIRO NA CABEÇA! - **esqueleto** {}"
           ],
           "finishers": [
             "O **esqueleto** te deu um 360 sem mira em você pela última vez!",

--- a/bot/data/text/vn.json
+++ b/bot/data/text/vn.json
@@ -1368,7 +1368,7 @@
             "**Bộ xương** quay xung quanh và 360 độ không nhắm vào bạn!",
             "Một mũi tên rơi xuống từ **Bộ xương**, chỉ có một.",
             "Một cú đánh đầu từ **Bộ xương** dành cho bạn!",
-            "BÙM! HEADSHOT! - **Bộ xương** {}"
+            "BÙM! HEADSHOT! - **Bộ xương** {current_year}"
           ],
           "finishers": [
             "**bộ xương** 360 noscopes bạn lần cuối!",

--- a/bot/data/text/vn.json
+++ b/bot/data/text/vn.json
@@ -1368,7 +1368,7 @@
             "**Bộ xương** quay xung quanh và 360 độ không nhắm vào bạn!",
             "Một mũi tên rơi xuống từ **Bộ xương**, chỉ có một.",
             "Một cú đánh đầu từ **Bộ xương** dành cho bạn!",
-            "BÙM! HEADSHOT! - **Bộ xương** 2025"
+            "BÙM! HEADSHOT! - **Bộ xương** {}"
           ],
           "finishers": [
             "**bộ xương** 360 noscopes bạn lần cuối!",


### PR DESCRIPTION
This PR adds two changes
- Years now do not need to be changed every year in the translation files
- License year updated to 2025
- Tested locally and works fine

One thing to be cautious about is if in future, any text requiring placeholders is added to any of the **mobs' attacks** which does not accept a year, this "_dynamic year_" system will need to be refactored.